### PR TITLE
matched nav below 1017 and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Horiseon Homepage
 
-- [Further Changes](#further-changes)
+- [Further Alterations](#further-alterations)
+- [Potential Issues/Improvements](#potential-issuesimprovements)
 - [Key Learnings](#key-learnings)
 - [Contributing and Feedback](#contributing-and-feedback)
 - [Credits](#credits)
@@ -18,12 +19,26 @@ The main goal of the project was to optimise for search engines by:
 
 ![Picture of the Homepage](./assets/images/Homepage.png)
 
-## Further Changes
+## Further Alterations
+
 Other alterations include:
 - Writing a README.
 - Fixing a non functioning link.
 - Tidying and condensing the stylesheet.
 - Adding alt descriptions to images.
+
+## Potential Issues/Improvements
+
+Added query/s to the html with potential improvements to address issues below:
+
+HTML
+- No meta for viewport data.
+- Consider alternate name for the page.
+- Consider an aria-label in place of a hidden img providing alt text.
+
+CSS 
+- Nav bar in header doesn't display properly at resolutions below 1017 (same as with starter code). Consider implementation of media queries.
+- Further elements break at very low resolutions - see above.
 
 ## Key Learnings
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -55,12 +55,16 @@ li {
 }
 
 /* updated with new nav element */
+/* resolution below 1017 breaks the display of this element both on the original as well as this updated css */
+/* added position to give this element a z-index in order for it to show in front of the backgorund image albeit with broken styling (basically identical to original page) */
 nav {
+    position: relative;
     padding-top: 15px;
     margin-right: 20px;
     float: right;
     font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
     font-size: 20px;
+    z-index: 2;
 }
 
 a {
@@ -68,7 +72,8 @@ a {
     text-decoration: none;
 }
 
-/* large background image, given position relative as an anchor for the sr-only image */
+/* large background image 
+given position relative as an anchor for the sr-only image as well as to apply a z-index so it appears behind nav below 1017 resolution */
 .hero {
     position: relative;
     height: 800px;
@@ -77,6 +82,7 @@ a {
     background-image: url("../images/digital-marketing-meeting.jpg");
     background-size: cover;
     background-position: center;
+    z-index: 1;
 }
 
 /* put in to hide the image used to provide an alt text for the background-image above */


### PR DESCRIPTION
Noticed display elements break below 1017 (both in starter code and updated) rather than below 768 as noted in the project README.

Implemented z-index so that elements appear in the same way as they did in the starter code. 

Note this doesn't resolve the issue merely matches the initial product.

Consider viewing section in updated README for potential site improvements to this and other issues.